### PR TITLE
Create unit tests and conftest for zoe.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,84 @@
+import os
+import pathlib
+import pytest
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+from zoe import AppWorxEnum, get_config, ScriptData
+
+@dataclass
+class FakeApwxArgs:
+    TNS_SERVICE_NAME: str
+    CONFIG_FILE_PATH: str
+    OUTPUT_FILE_PATH: str
+    OUTPUT_FILE_NAME: str
+    TEST_YN: str
+    DEBUG_YN: str
+    MAX_THREADS: str
+    MODE: str
+    P2P_SERVER: str
+    P2P_SCHEMA: str
+    OLD_ZOE_FILE: str = "old_zoe.txt"
+    NEW_ZOE_FILE: str = "new_zoe.txt"
+
+@dataclass
+class FakeApwx:
+    args: FakeApwxArgs
+    def db_connect(self, autocommit=False):
+        return MagicMock()
+
+TEST_BASE_PATH = pathlib.Path(os.path.dirname(__file__))
+CONFIG_PATH = str(TEST_BASE_PATH / "test_config.yaml")
+
+SCRIPT_ARGUMENTS_NEW = {
+    str(AppWorxEnum.TNS_SERVICE_NAME): "FAKE_DB",
+    str(AppWorxEnum.CONFIG_FILE_PATH): CONFIG_PATH,
+    str(AppWorxEnum.OUTPUT_FILE_PATH): str(TEST_BASE_PATH),
+    str(AppWorxEnum.OUTPUT_FILE_NAME): "zoe_report_new.txt",
+    str(AppWorxEnum.TEST_YN): "Y",
+    str(AppWorxEnum.DEBUG_YN): "N",
+    str(AppWorxEnum.MAX_THREADS): "1",
+    str(AppWorxEnum.MODE): "NEW",
+    str(AppWorxEnum.P2P_SERVER): "FAKE_SERVER",
+    str(AppWorxEnum.P2P_SCHEMA): "FAKE_SCHEMA",
+}
+
+SCRIPT_ARGUMENTS_DELTA = {
+    **SCRIPT_ARGUMENTS_NEW,
+    str(AppWorxEnum.MODE): "DELTA",
+    str(AppWorxEnum.OUTPUT_FILE_NAME): "zoe_report_delta.txt",
+    str(AppWorxEnum.OLD_ZOE_FILE): str(TEST_BASE_PATH / "old_zoe.txt"),
+    str(AppWorxEnum.NEW_ZOE_FILE): str(TEST_BASE_PATH / "new_zoe.txt"),
+}
+
+def new_fake_apwx(script_args: dict) -> FakeApwx:
+    return FakeApwx(
+        args=FakeApwxArgs(
+            TNS_SERVICE_NAME=script_args[str(AppWorxEnum.TNS_SERVICE_NAME)],
+            CONFIG_FILE_PATH=str(script_args[str(AppWorxEnum.CONFIG_FILE_PATH)]),
+            OUTPUT_FILE_PATH=str(script_args[str(AppWorxEnum.OUTPUT_FILE_PATH)]),
+            OUTPUT_FILE_NAME=script_args[str(AppWorxEnum.OUTPUT_FILE_NAME)],
+            TEST_YN=script_args[str(AppWorxEnum.TEST_YN)],
+            DEBUG_YN=script_args[str(AppWorxEnum.DEBUG_YN)],
+            MAX_THREADS=script_args[str(AppWorxEnum.MAX_THREADS)],
+            MODE=script_args[str(AppWorxEnum.MODE)],
+            P2P_SERVER=script_args[str(AppWorxEnum.P2P_SERVER)],
+            P2P_SCHEMA=script_args[str(AppWorxEnum.P2P_SCHEMA)],
+            OLD_ZOE_FILE=script_args.get(str(AppWorxEnum.OLD_ZOE_FILE), "old_zoe.txt"),
+            NEW_ZOE_FILE=script_args.get(str(AppWorxEnum.NEW_ZOE_FILE), "new_zoe.txt"),
+        )
+    )
+
+@pytest.fixture(scope="module")
+def script_data_new():
+    apwx = new_fake_apwx(SCRIPT_ARGUMENTS_NEW)
+    config = {"dummy": "value"}  # Replace with actual config structure if needed
+    dbh = MagicMock()
+    return ScriptData(apwx=apwx, dbh=dbh, config=config)
+
+@pytest.fixture(scope="module")
+def script_data_delta():
+    apwx = new_fake_apwx(SCRIPT_ARGUMENTS_DELTA)
+    config = {"dummy": "value"}  # Replace with actual config structure if needed
+    dbh = MagicMock()
+    return ScriptData(apwx=apwx, dbh=dbh, config=config)

--- a/test_zoe.py
+++ b/test_zoe.py
@@ -1,0 +1,71 @@
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from zoe import run, process_new_mode, process_delta_mode
+
+def test_run_new_mode(script_data_new, mocker):
+    apwx = script_data_new.apwx
+    mocker.patch("zoe.initialize", return_value=script_data_new)
+    mocker.patch("zoe.collect_zoe_records_multithreaded", return_value=["A|B|C|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56"])
+    output_file = Path(apwx.args.OUTPUT_FILE_PATH) / apwx.args.OUTPUT_FILE_NAME
+    if output_file.exists():
+        output_file.unlink()
+    result = run(apwx)
+    assert result is True
+    assert output_file.exists()
+    with open(output_file, "r") as f:
+        lines = [line.strip() for line in f.readlines() if line.strip()]
+    assert any("CDE0380" in line for line in lines)  # Header check
+    assert any("6|A|03|FTF|1|A|B|C" in line for line in lines)  # Detail check
+
+
+def test_run_delta_mode(script_data_delta, mocker, tmp_path):
+    apwx = script_data_delta.apwx
+    # Prepare old and new ZOE files
+    old_file = Path(apwx.args.OLD_ZOE_FILE)
+    new_file = Path(apwx.args.NEW_ZOE_FILE)
+    old_file.write_text("6|A|03|FTF|1|A|B|C|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56\n")
+    new_file.write_text("6|A|03|FTF|1|A|B|C|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56\n6|A|03|FTF|2|X|Y|Z|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56\n")
+    mocker.patch("zoe.get_zoe_file_hash", side_effect=[({'C': 'A|B|C|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56'}, 1), ({'C': 'A|B|C|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56', 'Z': 'X|Y|Z|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56'}, 2)])
+    output_file = Path(apwx.args.OUTPUT_FILE_PATH) / apwx.args.OUTPUT_FILE_NAME
+    if output_file.exists():
+        output_file.unlink()
+    result = run(apwx)
+    assert result is True
+    assert output_file.exists()
+    with open(output_file, "r") as f:
+        lines = [line.strip() for line in f.readlines() if line.strip()]
+    assert any("CDE0380" in line for line in lines)  # Header check
+    assert any("6|A|03|FTF" in line for line in lines)  # Detail check
+
+
+def test_process_new_mode_creates_file(script_data_new, mocker):
+    apwx = script_data_new.apwx
+    mocker.patch("zoe.collect_zoe_records_multithreaded", return_value=["A|B|C|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56"])
+    output_file = Path(apwx.args.OUTPUT_FILE_PATH) / apwx.args.OUTPUT_FILE_NAME
+    if output_file.exists():
+        output_file.unlink()
+    result = process_new_mode(apwx, script_data_new, str(output_file))
+    assert result is True
+    assert output_file.exists()
+    with open(output_file, "r") as f:
+        lines = [line.strip() for line in f.readlines() if line.strip()]
+    assert any("CDE0380" in line for line in lines)
+    assert any("6|A|03|FTF|1|A|B|C" in line for line in lines)
+
+
+def test_process_delta_mode_creates_file(script_data_delta, mocker):
+    apwx = script_data_delta.apwx
+    output_file = Path(apwx.args.OUTPUT_FILE_PATH) / apwx.args.OUTPUT_FILE_NAME
+    if output_file.exists():
+        output_file.unlink()
+    mocker.patch("zoe.get_zoe_file_hash", side_effect=[({'C': 'A|B|C|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56'}, 1), ({'C': 'A|B|C|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56', 'Z': 'X|Y|Z|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56'}, 2)])
+    result = process_delta_mode(apwx, str(output_file))
+    assert result is True
+    assert output_file.exists()
+    with open(output_file, "r") as f:
+        lines = [line.strip() for line in f.readlines() if line.strip()]
+    assert any("CDE0380" in line for line in lines)
+    assert any("6|A|03|FTF" in line for line in lines)


### PR DESCRIPTION
Add unit tests and conftest for `zoe.py` focusing on main functionalities.

These tests cover the `run`, `process_new_mode`, and `process_delta_mode` functions, ensuring their correct execution and the generation of output files in the test directory as requested.

---

[Open in Web](https://www.cursor.com/agents?id=bc-26d032d9-13bd-442d-984f-a7357dc059d7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-26d032d9-13bd-442d-984f-a7357dc059d7)